### PR TITLE
Alternative iterator interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,25 @@ int main() {
 
       cout << "The new record got assigned id " << db.last_insert_rowid() << endl;
 
-      // slects from user table on a condition ( age > 18 ) and executes
+      // selects from user table on a condition ( age > 18 ) and executes
       // the lambda for each row returned .
       db << "select age,name,weight from user where age > ? ;"
          << 18
          >> [&](int age, string name, double weight) {
             cout << age << ' ' << name << ' ' << weight << endl;
          };
+
+      // a for loop can be used too:
+      // with named variables
+      for(auto &&row : db << "select age,name,weight from user where age > ? ;" << 18) {
+         int age; string name; double weight;
+         row >> age >> name >> weight;
+         cout << age << ' ' << name << ' ' << weight << endl;
+      }
+      // or with a tuple
+      for(tuple<int, string, double> row : db << "select age,name,weight from user where age > ? ;" << 18) {
+         cout << get<0>(row) << ' ' << get<1>(row) << ' ' << get<2>(row) << endl;
+      }
 
       // selects the count(*) from user table
       // note that you can extract a single culumn single row result only to : int,long,long,float,double,string,u16string

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -239,7 +239,7 @@ namespace sqlite {
 #endif
 #ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 		template <typename T>
-		struct is_sqlite_value< std::optional<T> > : public is_sqlite_value<T> {};
+		struct is_sqlite_value< optional<T> > : public is_sqlite_value<T> {};
 #endif
 
 #ifdef _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -360,7 +360,7 @@ namespace sqlite {
 				throw errors::more_rows("not all rows extracted", binder.sql(), SQLITE_ROW);
 		}
 	}
-	void database_binder::execute() {
+	inline void database_binder::execute() {
 		for(auto &&row : *this)
 			(void)row;
 	}

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -269,12 +269,6 @@ namespace sqlite {
 				get_col_from_db(*_binder, next_index++, result);
 				return *this;
 			}
-			template<class T, typename = typename std::enable_if<detail::is_sqlite_value<T>::value, value_type &>::type>
-			operator T() {
-				T result;
-				*this >> result;
-				return result;
-			}
 			template<class ...Types>
 			value_type &operator >>(std::tuple<Types...>& values) {
 				assert(!next_index);

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -306,8 +306,6 @@ namespace sqlite {
 			return *this;
 		}
 
-		// Not well-defined
-		row_iterator operator++(int);
 		friend inline bool operator ==(const row_iterator &a, const row_iterator &b) {
 			return a._binder == b._binder;
 		}

--- a/hdr/sqlite_modern_cpp/utility/function_traits.h
+++ b/hdr/sqlite_modern_cpp/utility/function_traits.h
@@ -42,10 +42,11 @@ namespace sqlite {
 		> {
 			typedef ReturnType result_type;
 
+			using argument_tuple = std::tuple<Arguments...>;
 			template <std::size_t Index>
 			using argument = typename std::tuple_element<
 				Index,
-				std::tuple<Arguments...>
+				argument_tuple
 			>::type;
 
 			static const std::size_t arity = sizeof...(Arguments);

--- a/tests/readme_example.cc
+++ b/tests/readme_example.cc
@@ -45,7 +45,7 @@ int main() {
 		db << "select age,name,weight from user where age > ? ;"
 			<< 21
 			>> [&](int _age, string _name, double _weight) {
-				if(_age != age || _name != name) 
+				if(_age != age || _name != name)
 					exit(EXIT_FAILURE);
 				cout << _age << ' ' << _name << ' ' << _weight << endl;
 		};
@@ -54,13 +54,13 @@ int main() {
 			string _name;
 			double _weight;
 			row >> _age >> _name >> _weight;
-			if(_age != age || _name != name) 
+			if(_age != age || _name != name)
 				exit(EXIT_FAILURE);
 			cout << _age << ' ' << _name << ' ' << _weight << endl;
 		}
 
 		for(std::tuple<int, string, double> row : db << "select age,name,weight from user where age > ? ;" << 21) {
-			if(std::get<int>(row) != age || std::get<string>(row) != name) 
+			if(std::get<int>(row) != age || std::get<string>(row) != name)
 				exit(EXIT_FAILURE);
 			cout << std::get<int>(row) << ' ' << std::get<string>(row) << ' ' << std::get<double>(row) << endl;
 		}

--- a/tests/readme_example.cc
+++ b/tests/readme_example.cc
@@ -49,6 +49,21 @@ int main() {
 					exit(EXIT_FAILURE);
 				cout << _age << ' ' << _name << ' ' << _weight << endl;
 		};
+		for(auto &&row : db << "select age,name,weight from user where age > ? ;" << 21) {
+			int _age;
+			string _name;
+			double _weight;
+			row >> _age >> _name >> _weight;
+			if(_age != age || _name != name) 
+				exit(EXIT_FAILURE);
+			cout << _age << ' ' << _name << ' ' << _weight << endl;
+		}
+
+		for(std::tuple<int, string, double> row : db << "select age,name,weight from user where age > ? ;" << 21) {
+			if(std::get<int>(row) != age || std::get<string>(row) != name) 
+				exit(EXIT_FAILURE);
+			cout << std::get<int>(row) << ' ' << std::get<string>(row) << ' ' << std::get<double>(row) << endl;
+		}
 
 		// selects the count(*) from user table
 		// note that you can extract a single culumn single row result only to : int,long,long,float,double,string,u16string


### PR DESCRIPTION
I think this feels more natural than the interface from #103 and it makes lifetime questions easier.
The `database_binder` behaves like a container now:

```c++
for(auto &&row : db << "select age,name,weight from user where age > ? ;" << 21) {
  int _age;
  string _name;
  double _weight;
  row >> _age >> _name >> _weight;
  cout << _age << ' ' << _name << ' ' << _weight << endl;
}
// or
for(std::tuple<int, string, double> row : db << "select age,name,weight from user where age > ? ;" << 21) {
  cout << std::get<int>(row) << ' ' << std::get<string>(row) << ' ' << std::get<double>(row) << endl;
}
```
@Killili What do you think? It's not our usual stream-op interface, but I think this makes it clearer that the range doesn't exists independent from the statement. 