### PR TITLE
Catch exception objects by const reference

### DIFF
--- a/tests/blob_example.cc
+++ b/tests/blob_example.cc
@@ -52,7 +52,7 @@ int main()
 		//}
 
 	}
-	catch(sqlite_exception e)
+	catch(const sqlite_exception& e)
 	{
 		cout << "Unexpected error " << e.what() << endl;
 		exit(EXIT_FAILURE);

--- a/tests/flags.cc
+++ b/tests/flags.cc
@@ -92,7 +92,7 @@ int main()
 			} catch(errors::readonly&) {}
 		}
 	}
-	catch(sqlite_exception e)
+	catch(const sqlite_exception& e)
 	{
 		cout << "Unexpected error " << e.what() << endl;
 		exit(EXIT_FAILURE);

--- a/tests/functions.cc
+++ b/tests/functions.cc
@@ -52,7 +52,7 @@ int main()
       cout << number << "! = " << factorial << '\n';
     };
 	}
-	catch(sqlite_exception e)
+	catch(const sqlite_exception& e)
 	{
 		cout << "Unexpected error " << e.what() << endl;
 		exit(EXIT_FAILURE);

--- a/tests/functors.cc
+++ b/tests/functors.cc
@@ -43,7 +43,7 @@ int main() {
     }
 
   }
-  catch(sqlite_exception e) {
+  catch(const sqlite_exception& e) {
     cout << "Unexpected error " << e.what() << endl;
     exit(EXIT_FAILURE);
   }

--- a/tests/mov_ctor.cc
+++ b/tests/mov_ctor.cc
@@ -24,7 +24,7 @@ int main() {
   try {
   	dbFront dbf;
   }
-  catch(sqlite_exception e) {
+  catch(const sqlite_exception& e) {
     cout << "Unexpected error " << e.what() << endl;
     exit(EXIT_FAILURE);
   }

--- a/tests/nullptr_uniqueptr.cc
+++ b/tests/nullptr_uniqueptr.cc
@@ -35,7 +35,7 @@ int main() {
       cout << "OK all three values are nullptr" << endl;
     };
 
-  } catch(sqlite_exception e) {
+  } catch(const sqlite_exception& e) {
     cout << "Sqlite error " << e.what() << endl;
     exit(EXIT_FAILURE);
   } catch(...) {

--- a/tests/prepared_statment.cc
+++ b/tests/prepared_statment.cc
@@ -85,7 +85,7 @@ int main() {
 		}
 
 
-	} catch(sqlite_exception e) {
+	} catch(const sqlite_exception& e) {
 		cout << "Unexpected error " << e.what() << endl;
 		exit(EXIT_FAILURE);
 	} catch(...) {

--- a/tests/shared_connection.cc
+++ b/tests/shared_connection.cc
@@ -29,7 +29,7 @@ int main() {
 		}
 
 
-	} catch(sqlite_exception e) {
+	} catch(const sqlite_exception& e) {
 		cout << "Unexpected error " << e.what() << endl;
 		exit(EXIT_FAILURE);
 	} catch(...) {

--- a/tests/simple_examples.cc
+++ b/tests/simple_examples.cc
@@ -31,7 +31,7 @@ int main()
 		if(test != 2) exit(EXIT_FAILURE);
 		
 	}
-	catch(sqlite_exception e)
+	catch(const sqlite_exception& e)
 	{
 		cout << "Unexpected error " << e.what() << endl;
 		exit(EXIT_FAILURE);

--- a/tests/sqlcipher.cc
+++ b/tests/sqlcipher.cc
@@ -58,7 +58,7 @@ int main()
 		  db << "INSERT INTO foo VALUES (?, ?)" << 3 << "fail";
 		}
 	}
-	catch(sqlite_exception e)
+	catch(const sqlite_exception& e)
 	{
 		cout << "Unexpected error " << e.what() << endl;
 		exit(EXIT_FAILURE);

--- a/tests/variant.cc
+++ b/tests/variant.cc
@@ -38,7 +38,7 @@ int main()
 			exit(EXIT_FAILURE);
 		}
 	}
-	catch(sqlite_exception e)
+	catch(const sqlite_exception& e)
 	{
 		cout << "Unexpected error " << e.what() << endl;
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
Testing with latest GCC git master (8.0.1) results in errors such as:

```
tests/flags.cc: In function ‘int main()’:
tests/flags.cc:99:25: error: catching polymorphic type ‘class sqlite::sqlite_exception’ by value [-Werror=catch-value=]
  catch(sqlite_exception e)
                         ^
```

`sqlite_exception` should ideally be caught by reference (and, preferably, const reference) to avoid potential issues such as object slicing and memory exhaustion triggering further exceptions.