### PR TITLE
Define __cpp_lib_uncaught_exceptions if building C++17 mode

### DIFF
--- a/hdr/sqlite_modern_cpp/utility/uncaught_exceptions.h
+++ b/hdr/sqlite_modern_cpp/utility/uncaught_exceptions.h
@@ -4,9 +4,23 @@
 #include <exception>
 #include <iostream>
 
+// Consider that std::uncaught_exceptions is available if explicitly indicated
+// by the standard library, if compiler advertises full C++17 support or, as a
+// special case, for MSVS 2015+ (which doesn't define __cplusplus correctly by
+// default as of 2017.7 version and couldn't do it at all until it).
+#ifndef MODERN_SQLITE_UNCAUGHT_EXCEPTIONS_SUPPORT
+#ifdef __cpp_lib_uncaught_exceptions
+#define MODERN_SQLITE_UNCAUGHT_EXCEPTIONS_SUPPORT
+#elif __cplusplus >= 201703L
+#define MODERN_SQLITE_UNCAUGHT_EXCEPTIONS_SUPPORT
+#elif defined(_MSC_VER) && _MSC_VER >= 1900
+#define MODERN_SQLITE_UNCAUGHT_EXCEPTIONS_SUPPORT
+#endif
+#endif
+
 namespace sqlite {
 	namespace utility {
-#ifdef __cpp_lib_uncaught_exceptions
+#ifdef MODERN_SQLITE_UNCAUGHT_EXCEPTIONS_SUPPORT
 		class UncaughtExceptionDetector {
 		public:
 			operator bool() {

--- a/tests/exception_dont_execute_nested.cc
+++ b/tests/exception_dont_execute_nested.cc
@@ -21,7 +21,7 @@ struct A {
 };
 
 TEST_CASE("Nested prepered statements wont execute", "[nested_prepared_statements]") {
-#ifdef __cpp_lib_uncaught_exceptions
+#ifdef MODERN_SQLITE_UNCAUGHT_EXCEPTIONS_SUPPORT
 	try {
 		A a;
 		throw 1;


### PR DESCRIPTION
This notably avoids warnings about std::uncaught_exception() being
deprecated from MSVS 2017 (but note that to get it to define __cplusplus
correctly, both /std:c++17 and /Zc:__cplusplus options need to be used,
and these options are only available starting from MSVS 15.7 release).