### PR TITLE
Always provide an explicit case in a switch

### DIFF
--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -45,7 +45,8 @@ namespace sqlite {
 #define SQLITE_MODERN_CPP_ERROR_CODE(NAME,name,derived)     \
 				case SQLITE_ ## NAME: switch(error_code) {          \
 					derived                                           \
-					default: throw name(error_code, sql); \
+					case SQLITE_ ## NAME:                             \
+					default: throw name(error_code, sql);             \
 				}
 #define SQLITE_MODERN_CPP_ERROR_CODE_EXTENDED(BASE,SUB,base,sub) \
 					case SQLITE_ ## BASE ## _ ## SUB: throw base ## _ ## sub(error_code, sql);


### PR DESCRIPTION
This avoids having a switch without a case by being more specific withthe default: We expect the default to be hit mostly by errors of the form `SQLITE_ ## NAME`, so we can specify an explicit case for this.
This is no functional change, but it might explain  better what is going on.
AFAICT this would stop Visual C++ from complaining.