### PR TITLE
Do not nest switch to avoid missing case ...:

### DIFF
--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -41,16 +41,20 @@ namespace sqlite {
 		class invalid_utf16: public sqlite_exception { using sqlite_exception::sqlite_exception; };
 
 		static void throw_sqlite_error(const int& error_code, const std::string &sql = "") {
-			switch(error_code & 0xFF) {
-#define SQLITE_MODERN_CPP_ERROR_CODE(NAME,name,derived)     \
-				case SQLITE_ ## NAME: switch(error_code) {          \
-					derived                                           \
-					default: throw name(error_code, sql); \
-				}
+			switch(error_code) {
+#define SQLITE_MODERN_CPP_ERROR_CODE(NAME,name,derived)   \
+				derived
 #define SQLITE_MODERN_CPP_ERROR_CODE_EXTENDED(BASE,SUB,base,sub) \
-					case SQLITE_ ## BASE ## _ ## SUB: throw base ## _ ## sub(error_code, sql);
+				case SQLITE_ ## BASE ## _ ## SUB: throw base ## _ ## sub(error_code, sql);
 #include "lists/error_codes.h"
 #undef SQLITE_MODERN_CPP_ERROR_CODE_EXTENDED
+#undef SQLITE_MODERN_CPP_ERROR_CODE
+				default:;
+			}
+			switch(error_code & 0xFF) {
+#define SQLITE_MODERN_CPP_ERROR_CODE(NAME,name,derived)     \
+				case SQLITE_ ## NAME: throw name(error_code, sql);
+#include "lists/error_codes.h"
 #undef SQLITE_MODERN_CPP_ERROR_CODE
 				default: throw sqlite_exception(error_code, sql);
 			}


### PR DESCRIPTION
This is an implementation of the idea of @aminroosta to fix #155:
Instead of the current nested construction for error handling, it just uses two switch statements: One for the extended error codes, one for the normal ones.
This is an alternative to #165, so merging this would close #165.