### PR TITLE
Use std::string_view as argument instead of std::string on C++17 Compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ OPTION(ENABLE_SQLCIPHER_TESTS "enable sqlchipher test")
 
 # Creates the file compile_commands.json in the build directory.
 SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 include("cmake/HunterGate.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ else()
 endif()
 
 catch_discover_tests(tests)
+target_compile_options(tests PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus> )
 
 # Place the file in the source directory, permitting us to place a single configuration file for YCM there.
 # YCM is the code-completion engine for (neo)vim https://github.com/Valloric/YouCompleteMe

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ int main() {
       //      int ,long, long long, float, double
       //      string , u16string
       // sqlite3 only supports utf8 and utf16 strings, you should use std::string for utf8 and std::u16string for utf16.
+	  // If you're using c++17, it takes `string_view` and `u16string_view` as arguments
       // note that u"my text" is a utf16 string literal of type char16_t * .
       db << "insert into user (age,name,weight) values (?,?,?);"
          << 20

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -42,7 +42,7 @@ namespace sqlite {
 
 		void execute();
 
-		STR_REF sql() {
+		std::string sql() {
 #if SQLITE_VERSION_NUMBER >= 3014000
 			auto sqlite_deleter = [](void *ptr) {sqlite3_free(ptr);};
 			std::unique_ptr<char, decltype(sqlite_deleter)> str(sqlite3_expanded_sql(_stmt.get()), sqlite_deleter);
@@ -52,7 +52,7 @@ namespace sqlite {
 #endif
 		}
 
-		STR_REF original_sql() {
+		std::string original_sql() {
 			return sqlite3_sql(_stmt.get());
 		}
 

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -85,11 +85,11 @@ namespace sqlite {
 			return ++_inx;
 		}
 
-		sqlite3_stmt* _prepare(U16STR_REF sql) {
+		sqlite3_stmt* _prepare(u16str_ref sql) {
 			return _prepare(utility::utf16_to_utf8(sql));
 		}
 
-		sqlite3_stmt* _prepare(STR_REF sql) {
+		sqlite3_stmt* _prepare(str_ref sql) {
 			int hresult;
 			sqlite3_stmt* tmp = nullptr;
 			const char *remaining;
@@ -105,13 +105,13 @@ namespace sqlite {
 
 	public:
 
-		database_binder(std::shared_ptr<sqlite3> db, U16STR_REF  sql):
+		database_binder(std::shared_ptr<sqlite3> db, u16str_ref  sql):
 			_db(db),
 			_stmt(_prepare(sql), sqlite3_finalize),
 			_inx(0) {
 		}
 
-		database_binder(std::shared_ptr<sqlite3> db, STR_REF sql):
+		database_binder(std::shared_ptr<sqlite3> db, str_ref sql):
 			_db(db),
 			_stmt(_prepare(sql), sqlite3_finalize),
 			_inx(0) {
@@ -372,7 +372,7 @@ namespace sqlite {
 				*this << R"(PRAGMA encoding = "UTF-16";)";
 		}
 
-		database(const std::u16string &db_name, const sqlite_config &config = {}): database(utility::utf16_to_utf8(db_name.data()), config) {
+		database(const std::u16string &db_name, const sqlite_config &config = {}): database(utility::utf16_to_utf8(db_name), config) {
 			if (config.encoding == Encoding::ANY)
 				*this << R"(PRAGMA encoding = "UTF-16";)";
 		}
@@ -380,11 +380,11 @@ namespace sqlite {
 		database(std::shared_ptr<sqlite3> db):
 			_db(db) {}
 
-		database_binder operator<<(STR_REF sql) {
+		database_binder operator<<(str_ref sql) {
 			return database_binder(_db, sql);
 		}
 
-		database_binder operator<<(U16STR_REF sql) {
+		database_binder operator<<(u16str_ref sql) {
 			return database_binder(_db, sql);
 		}
 
@@ -419,7 +419,7 @@ namespace sqlite {
 
 			auto funcPtr = new auto(std::make_pair(std::forward<StepFunction>(step), std::forward<FinalFunction>(final)));
 			if(int result = sqlite3_create_function_v2(
-					_db.get(), name.data(), traits::arity - 1, SQLITE_UTF8, funcPtr, nullptr,
+					_db.get(), name.c_str(), traits::arity - 1, SQLITE_UTF8, funcPtr, nullptr,
 					sql_function_binder::step<ContextType, traits::arity, typename std::remove_reference<decltype(*funcPtr)>::type>,
 					sql_function_binder::final<ContextType, typename std::remove_reference<decltype(*funcPtr)>::type>,
 					[](void* ptr){

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -407,7 +407,7 @@ namespace sqlite {
 		}
 
 		template <typename Function>
-		void define(const STR_REF &name, Function&& func) {
+		void define(const std::string &name, Function&& func) {
 			typedef utility::function_traits<Function> traits;
 
 			auto funcPtr = new auto(std::forward<Function>(func));
@@ -421,7 +421,7 @@ namespace sqlite {
 		}
 
 		template <typename StepFunction, typename FinalFunction>
-		void define(const STR_REF &name, StepFunction&& step, FinalFunction&& final) {
+		void define(const std::string &name, StepFunction&& step, FinalFunction&& final) {
 			typedef utility::function_traits<StepFunction> traits;
 			using ContextType = typename std::remove_reference<typename traits::template argument<0>>::type;
 

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -362,7 +362,7 @@ namespace sqlite {
 		std::shared_ptr<sqlite3> _db;
 
 	public:
-		database(const STR_REF &db_name, const sqlite_config &config = {}): _db(nullptr) {
+		database(const std::string &db_name, const sqlite_config &config = {}): _db(nullptr) {
 			sqlite3* tmp = nullptr;
 			auto ret = sqlite3_open_v2(db_name.data(), &tmp, static_cast<int>(config.flags), config.zVfs);
 			_db = std::shared_ptr<sqlite3>(tmp, [=](sqlite3* ptr) { sqlite3_close_v2(ptr); }); // this will close the connection eventually when no longer needed.
@@ -372,14 +372,8 @@ namespace sqlite {
 				*this << R"(PRAGMA encoding = "UTF-16";)";
 		}
 
-		database(const U16STR_REF &db_name, const sqlite_config &config = {}): _db(nullptr) {
-			auto db_name_utf8 = utility::utf16_to_utf8(db_name.data());
-			sqlite3* tmp = nullptr;
-			auto ret = sqlite3_open_v2(db_name_utf8.data(), &tmp, static_cast<int>(config.flags), config.zVfs);
-			_db = std::shared_ptr<sqlite3>(tmp, [=](sqlite3* ptr) { sqlite3_close_v2(ptr); }); // this will close the connection eventually when no longer needed.
-			if(ret != SQLITE_OK) errors::throw_sqlite_error(_db ? sqlite3_extended_errcode(_db.get()) : ret);
-			sqlite3_extended_result_codes(_db.get(), true);
-			if(config.encoding != Encoding::UTF8)
+		database(const std::u16string &db_name, const sqlite_config &config = {}): database(utility::utf16_to_utf8(db_name.data()), config) {
+			if (config.encoding == Encoding::ANY)
 				*this << R"(PRAGMA encoding = "UTF-16";)";
 		}
 

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -86,22 +86,14 @@ namespace sqlite {
 		}
 
 		sqlite3_stmt* _prepare(const U16STR_REF& sql) {
-			//return _prepare(utility::utf16_to_utf8(sql));
-			int hresult;
-			sqlite3_stmt* tmp = nullptr;
-			const void *remaining;
-			hresult = sqlite3_prepare16_v2(_db.get(), sql.data(), -1, &tmp, &remaining);
-			if (hresult != SQLITE_OK) errors::throw_sqlite_error(hresult, utility::utf16_to_utf8(sql.data()));
-			if (!std::all_of(static_cast<const char16_t*>(remaining), sql.data() + sql.size(), [](char16_t ch) {return std::isspace(ch); }))
-				throw errors::more_statements("Multiple semicolon separated statements are unsupported", utility::utf16_to_utf8(sql.data()));
-			return tmp;
+			return _prepare(utility::utf16_to_utf8(sql));
 		}
 
 		sqlite3_stmt* _prepare(const STR_REF& sql) {
 			int hresult;
 			sqlite3_stmt* tmp = nullptr;
 			const char *remaining;
-			hresult = sqlite3_prepare_v2(_db.get(), sql.data(), -1, &tmp, &remaining);
+			hresult = sqlite3_prepare_v2(_db.get(), sql.data(), sql.length(), &tmp, &remaining);
 			if(hresult != SQLITE_OK) errors::throw_sqlite_error(hresult, sql);
 			if(!std::all_of(remaining, sql.data() + sql.size(), [](char ch) {return std::isspace(ch);}))
 				throw errors::more_statements("Multiple semicolon separated statements are unsupported", sql);

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -85,11 +85,11 @@ namespace sqlite {
 			return ++_inx;
 		}
 
-		sqlite3_stmt* _prepare(const U16STR_REF& sql) {
+		sqlite3_stmt* _prepare(U16STR_REF sql) {
 			return _prepare(utility::utf16_to_utf8(sql));
 		}
 
-		sqlite3_stmt* _prepare(const STR_REF& sql) {
+		sqlite3_stmt* _prepare(STR_REF sql) {
 			int hresult;
 			sqlite3_stmt* tmp = nullptr;
 			const char *remaining;
@@ -105,13 +105,13 @@ namespace sqlite {
 
 	public:
 
-		database_binder(std::shared_ptr<sqlite3> db, U16STR_REF const & sql):
+		database_binder(std::shared_ptr<sqlite3> db, U16STR_REF  sql):
 			_db(db),
 			_stmt(_prepare(sql), sqlite3_finalize),
 			_inx(0) {
 		}
 
-		database_binder(std::shared_ptr<sqlite3> db, STR_REF const & sql):
+		database_binder(std::shared_ptr<sqlite3> db, STR_REF sql):
 			_db(db),
 			_stmt(_prepare(sql), sqlite3_finalize),
 			_inx(0) {
@@ -380,20 +380,12 @@ namespace sqlite {
 		database(std::shared_ptr<sqlite3> db):
 			_db(db) {}
 
-		database_binder operator<<(const STR_REF& sql) {
+		database_binder operator<<(STR_REF sql) {
 			return database_binder(_db, sql);
 		}
 
-		database_binder operator<<(const char* sql) {
-			return *this << STR_REF(sql);
-		}
-
-		database_binder operator<<(const U16STR_REF& sql) {
+		database_binder operator<<(U16STR_REF sql) {
 			return database_binder(_db, sql);
-		}
-
-		database_binder operator<<(const char16_t* sql) {
-			return *this << U16STR_REF(sql);
 		}
 
 		connection_type connection() const { return _db; }
@@ -646,5 +638,4 @@ namespace sqlite {
 		}
 	}
 }
-#undef STR_REF
-#undef U16STR_REF
+

--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -9,11 +9,11 @@ namespace sqlite {
 
 	class sqlite_exception: public std::runtime_error {
 	public:
-		sqlite_exception(const char* msg, STR_REF sql, int code = -1): runtime_error(msg), code(code), sql(sql) {}
-		sqlite_exception(int code, STR_REF sql): runtime_error(sqlite3_errstr(code)), code(code), sql(sql) {}
+		sqlite_exception(const char* msg, STR_REF sql, int code = -1): runtime_error(msg), code(code), sql(std::move(sql)) {}
+		sqlite_exception(int code, STR_REF sql): runtime_error(sqlite3_errstr(code)), code(code), sql(std::move(sql)) {}
 		int get_code() const {return code & 0xFF;}
 		int get_extended_code() const {return code;}
-		STR_REF get_sql() const {return sql;}
+		std::string get_sql() const {return sql;}
 	private:
 		int code;
 		std::string sql;

--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -9,8 +9,8 @@ namespace sqlite {
 
 	class sqlite_exception: public std::runtime_error {
 	public:
-		sqlite_exception(const char* msg, STR_REF sql, int code = -1): runtime_error(msg), code(code), sql(std::move(sql)) {}
-		sqlite_exception(int code, STR_REF sql): runtime_error(sqlite3_errstr(code)), code(code), sql(std::move(sql)) {}
+		sqlite_exception(const char* msg, str_ref sql, int code = -1): runtime_error(msg), code(code), sql(sql) {}
+		sqlite_exception(int code, str_ref sql): runtime_error(sqlite3_errstr(code)), code(code), sql(sql) {}
 		int get_code() const {return code & 0xFF;}
 		int get_extended_code() const {return code;}
 		std::string get_sql() const {return sql;}
@@ -40,7 +40,7 @@ namespace sqlite {
 		class more_statements: public sqlite_exception { using sqlite_exception::sqlite_exception; }; // Prepared statements can only contain one statement
 		class invalid_utf16: public sqlite_exception { using sqlite_exception::sqlite_exception; };
 
-		static void throw_sqlite_error(const int& error_code, const STR_REF &sql = "") {
+		static void throw_sqlite_error(const int& error_code, str_ref sql = "") {
 			switch(error_code & 0xFF) {
 #define SQLITE_MODERN_CPP_ERROR_CODE(NAME,name,derived)     \
 				case SQLITE_ ## NAME: switch(error_code) {          \

--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -9,11 +9,11 @@ namespace sqlite {
 
 	class sqlite_exception: public std::runtime_error {
 	public:
-		sqlite_exception(const char* msg, std::string sql, int code = -1): runtime_error(msg), code(code), sql(sql) {}
-		sqlite_exception(int code, std::string sql): runtime_error(sqlite3_errstr(code)), code(code), sql(sql) {}
+		sqlite_exception(const char* msg, std::string_view sql, int code = -1): runtime_error(msg), code(code), sql(sql) {}
+		sqlite_exception(int code, std::string_view sql): runtime_error(sqlite3_errstr(code)), code(code), sql(sql) {}
 		int get_code() const {return code & 0xFF;}
 		int get_extended_code() const {return code;}
-		std::string get_sql() const {return sql;}
+		std::string_view get_sql() const {return sql;}
 	private:
 		int code;
 		std::string sql;
@@ -40,7 +40,7 @@ namespace sqlite {
 		class more_statements: public sqlite_exception { using sqlite_exception::sqlite_exception; }; // Prepared statements can only contain one statement
 		class invalid_utf16: public sqlite_exception { using sqlite_exception::sqlite_exception; };
 
-		static void throw_sqlite_error(const int& error_code, const std::string &sql = "") {
+		static void throw_sqlite_error(const int& error_code, const std::string_view &sql = "") {
 			switch(error_code & 0xFF) {
 #define SQLITE_MODERN_CPP_ERROR_CODE(NAME,name,derived)     \
 				case SQLITE_ ## NAME: switch(error_code) {          \

--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -9,11 +9,11 @@ namespace sqlite {
 
 	class sqlite_exception: public std::runtime_error {
 	public:
-		sqlite_exception(const char* msg, std::string_view sql, int code = -1): runtime_error(msg), code(code), sql(sql) {}
-		sqlite_exception(int code, std::string_view sql): runtime_error(sqlite3_errstr(code)), code(code), sql(sql) {}
+		sqlite_exception(const char* msg, STR_REF sql, int code = -1): runtime_error(msg), code(code), sql(sql) {}
+		sqlite_exception(int code, STR_REF sql): runtime_error(sqlite3_errstr(code)), code(code), sql(sql) {}
 		int get_code() const {return code & 0xFF;}
 		int get_extended_code() const {return code;}
-		std::string_view get_sql() const {return sql;}
+		STR_REF get_sql() const {return sql;}
 	private:
 		int code;
 		std::string sql;
@@ -40,7 +40,7 @@ namespace sqlite {
 		class more_statements: public sqlite_exception { using sqlite_exception::sqlite_exception; }; // Prepared statements can only contain one statement
 		class invalid_utf16: public sqlite_exception { using sqlite_exception::sqlite_exception; };
 
-		static void throw_sqlite_error(const int& error_code, const std::string_view &sql = "") {
+		static void throw_sqlite_error(const int& error_code, const STR_REF &sql = "") {
 			switch(error_code & 0xFF) {
 #define SQLITE_MODERN_CPP_ERROR_CODE(NAME,name,derived)     \
 				case SQLITE_ ## NAME: switch(error_code) {          \

--- a/hdr/sqlite_modern_cpp/log.h
+++ b/hdr/sqlite_modern_cpp/log.h
@@ -93,9 +93,9 @@ namespace sqlite {
 			  }
 			});
 
-		sqlite3_config(SQLITE_CONFIG_LOG, (void(*)(void*,int,const char*))[](void *functor, int error_code, const char *errstr) {
+		sqlite3_config(SQLITE_CONFIG_LOG, static_cast<void(*)(void*,int,const char*)>([](void *functor, int error_code, const char *errstr) {
 				(*static_cast<decltype(ptr.get())>(functor))(error_code, errstr);
-			}, ptr.get());
+			}), ptr.get());
 		detail::store_error_log_data_pointer(std::move(ptr));
 	}
 }

--- a/hdr/sqlite_modern_cpp/type_wrapper.h
+++ b/hdr/sqlite_modern_cpp/type_wrapper.h
@@ -200,7 +200,7 @@ namespace sqlite {
 
 	// Convert char* to string_view to trigger op<<(..., const str_ref )
 	template<std::size_t N> inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const char16_t(&STR)[N]) { 
-		return sqlite3_bind_text16(stmt, inx, &STR[0], N-1, SQLITE_TRANSIENT);
+		return sqlite3_bind_text16(stmt, inx, &STR[0], sizeof(char16_t) * (N-1), SQLITE_TRANSIENT);
 	}
 
 	inline std::u16string get_col_from_db(sqlite3_stmt* stmt, int inx, result_type<std::u16string>) {

--- a/hdr/sqlite_modern_cpp/type_wrapper.h
+++ b/hdr/sqlite_modern_cpp/type_wrapper.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <vector>
 #ifdef __cplusplus >= 201703 && __has_include(<string_view>)
+#include <string_view>
 #define STR_REF std::string_view
 #define U16STR_REF std::u16string_view
 #else

--- a/hdr/sqlite_modern_cpp/type_wrapper.h
+++ b/hdr/sqlite_modern_cpp/type_wrapper.h
@@ -6,6 +6,7 @@
 #include <vector>
 #ifdef __has_include
 #if __cplusplus >= 201703 && __has_include(<string_view>)
+#define MODERN_SQLITE_STRINGVIEW_SUPPORT
 #include <string_view>
 #define STR_REF std::string_view
 #define U16STR_REF std::u16string_view
@@ -164,8 +165,6 @@ namespace sqlite {
 
 	// STR_REF
 	template<>
-	struct has_sqlite_type<STR_REF, SQLITE3_TEXT, void> : std::true_type {};
-	template<>
 	struct has_sqlite_type<std::string, SQLITE3_TEXT, void> : std::true_type {};
 	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const STR_REF& val) {
 		return sqlite3_bind_text(stmt, inx, val.data(), -1, SQLITE_TRANSIENT);
@@ -187,8 +186,6 @@ namespace sqlite {
 		sqlite3_result_text(db, val.data(), -1, SQLITE_TRANSIENT);
 	}
 	// U16STR_REF
-	template<>
-	struct has_sqlite_type<U16STR_REF, SQLITE3_TEXT, void> : std::true_type {};
 	template<>
 	struct has_sqlite_type<std::u16string, SQLITE3_TEXT, void> : std::true_type {};
 	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const U16STR_REF& val) {

--- a/hdr/sqlite_modern_cpp/type_wrapper.h
+++ b/hdr/sqlite_modern_cpp/type_wrapper.h
@@ -4,10 +4,15 @@
 #include <string>
 #include <memory>
 #include <vector>
-#ifdef __cplusplus >= 201703 && __has_include(<string_view>)
+#ifdef __has_include
+#if __cplusplus >= 201703 && __has_include(<string_view>)
 #include <string_view>
 #define STR_REF std::string_view
 #define U16STR_REF std::u16string_view
+#else
+#define STR_REF std::string
+#define U16STR_REF std::u16string
+#endif
 #else
 #define STR_REF std::string
 #define U16STR_REF std::u16string

--- a/hdr/sqlite_modern_cpp/type_wrapper.h
+++ b/hdr/sqlite_modern_cpp/type_wrapper.h
@@ -150,16 +150,17 @@ namespace sqlite {
 		sqlite3_result_null(db);
 	}
 
-	// std::string
+	// std::string_view
+	template<>
+	struct has_sqlite_type<std::string_view, SQLITE3_TEXT, void> : std::true_type {};
 	template<>
 	struct has_sqlite_type<std::string, SQLITE3_TEXT, void> : std::true_type {};
-
-	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const std::string& val) {
+	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const std::string_view& val) {
 		return sqlite3_bind_text(stmt, inx, val.data(), -1, SQLITE_TRANSIENT);
 	}
 
-	// Convert char* to string to trigger op<<(..., const std::string )
-	template<std::size_t N> inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const char(&STR)[N]) { return bind_col_in_db(stmt, inx, std::string(STR, N-1)); }
+	// Convert char* to string_view to trigger op<<(..., const std::string_view )
+	template<std::size_t N> inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const char(&STR)[N]) { return bind_col_in_db(stmt, inx, std::string_view(STR, N-1)); }
 
 	inline std::string get_col_from_db(sqlite3_stmt* stmt, int inx, result_type<std::string>) {
 		return sqlite3_column_type(stmt, inx) == SQLITE_NULL ? std::string() :
@@ -170,30 +171,31 @@ namespace sqlite {
 			std::string(reinterpret_cast<char const *>(sqlite3_value_text(value)), sqlite3_value_bytes(value));
 	}
 
-	inline void store_result_in_db(sqlite3_context* db, const std::string& val) {
+	inline void store_result_in_db(sqlite3_context* db, const std::string_view& val) {
 		sqlite3_result_text(db, val.data(), -1, SQLITE_TRANSIENT);
 	}
-	// std::u16string
+	// std::u16string_view
+	template<>
+	struct has_sqlite_type<std::u16string_view, SQLITE3_TEXT, void> : std::true_type {};
 	template<>
 	struct has_sqlite_type<std::u16string, SQLITE3_TEXT, void> : std::true_type {};
-
-	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const std::u16string& val) {
+	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const std::u16string_view& val) {
 		return sqlite3_bind_text16(stmt, inx, val.data(), -1, SQLITE_TRANSIENT);
 	}
 
-	// Convert char* to string to trigger op<<(..., const std::string )
-	template<std::size_t N> inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const char16_t(&STR)[N]) { return bind_col_in_db(stmt, inx, std::u16string(STR, N-1)); }
+	// Convert char* to string_view to trigger op<<(..., const std::string_view )
+	template<std::size_t N> inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const char16_t(&STR)[N]) { return bind_col_in_db(stmt, inx, std::u16string_view(STR, N-1)); }
 
 	inline std::u16string get_col_from_db(sqlite3_stmt* stmt, int inx, result_type<std::u16string>) {
 		return sqlite3_column_type(stmt, inx) == SQLITE_NULL ? std::u16string() :
 			std::u16string(reinterpret_cast<char16_t const *>(sqlite3_column_text16(stmt, inx)), sqlite3_column_bytes16(stmt, inx));
 	}
-	inline std::u16string  get_val_from_db(sqlite3_value *value, result_type<std::u16string >) {
+	inline std::u16string  get_val_from_db(sqlite3_value *value, result_type<std::u16string>) {
 		return sqlite3_value_type(value) == SQLITE_NULL ? std::u16string() :
 			std::u16string(reinterpret_cast<char16_t const *>(sqlite3_value_text16(value)), sqlite3_value_bytes16(value));
 	}
 
-	inline void store_result_in_db(sqlite3_context* db, const std::u16string& val) {
+	inline void store_result_in_db(sqlite3_context* db, const std::u16string_view& val) {
 		sqlite3_result_text16(db, val.data(), -1, SQLITE_TRANSIENT);
 	}
 

--- a/hdr/sqlite_modern_cpp/type_wrapper.h
+++ b/hdr/sqlite_modern_cpp/type_wrapper.h
@@ -7,16 +7,7 @@
 #ifdef __has_include
 #if __cplusplus >= 201703 && __has_include(<string_view>)
 #define MODERN_SQLITE_STRINGVIEW_SUPPORT
-#include <string_view>
-#define STR_REF std::string_view
-#define U16STR_REF std::u16string_view
-#else
-#define STR_REF std::string
-#define U16STR_REF std::u16string
 #endif
-#else
-#define STR_REF std::string
-#define U16STR_REF std::u16string
 #endif
 #ifdef __has_include
 #if __cplusplus > 201402 && __has_include(<optional>)
@@ -44,7 +35,14 @@
 #ifdef MODERN_SQLITE_STD_VARIANT_SUPPORT
 #include <variant>
 #endif
-
+#ifdef MODERN_SQLITE_STRINGVIEW_SUPPORT
+#include <string_view>
+#define STR_REF std::string_view
+#define U16STR_REF std::u16string_view
+#else
+#define STR_REF std::string
+#define U16STR_REF std::u16string
+#endif
 #include <sqlite3.h>
 #include "errors.h"
 

--- a/hdr/sqlite_modern_cpp/type_wrapper.h
+++ b/hdr/sqlite_modern_cpp/type_wrapper.h
@@ -45,8 +45,8 @@ namespace sqlite
 #else
 namespace sqlite
 {
-	typedef const std::string& sqlite::str_ref;
-	typedef const std::u16string& sqlite::u16str_ref;
+	typedef const std::string& str_ref;
+	typedef const std::u16string& u16str_ref;
 }
 #endif
 #include <sqlite3.h>

--- a/hdr/sqlite_modern_cpp/type_wrapper.h
+++ b/hdr/sqlite_modern_cpp/type_wrapper.h
@@ -37,11 +37,17 @@
 #endif
 #ifdef MODERN_SQLITE_STRINGVIEW_SUPPORT
 #include <string_view>
-typedef const std::string_view STR_REF;
-typedef const std::u16string_view U16STR_REF;
+namespace sqlite
+{
+	typedef const std::string_view str_ref;
+	typedef const std::u16string_view u16str_ref;
+}
 #else
-typedef const std::string& STR_REF;
-typedef const std::u16string& U16STR_REF;
+namespace sqlite
+{
+	typedef const std::string& sqlite::str_ref;
+	typedef const std::u16string& sqlite::u16str_ref;
+}
 #endif
 #include <sqlite3.h>
 #include "errors.h"
@@ -161,14 +167,14 @@ namespace sqlite {
 		sqlite3_result_null(db);
 	}
 
-	// STR_REF
+	// str_ref
 	template<>
 	struct has_sqlite_type<std::string, SQLITE3_TEXT, void> : std::true_type {};
-	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, STR_REF val) {
+	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, str_ref val) {
 		return sqlite3_bind_text(stmt, inx, val.data(), val.length(), SQLITE_TRANSIENT);
 	}
 
-	// Convert char* to string_view to trigger op<<(..., const STR_REF )
+	// Convert char* to string_view to trigger op<<(..., const str_ref )
 	template<std::size_t N> inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const char(&STR)[N]) { 
 		return sqlite3_bind_text(stmt, inx, &STR[0], N-1, SQLITE_TRANSIENT); 
 	}
@@ -182,17 +188,17 @@ namespace sqlite {
 			std::string(reinterpret_cast<char const *>(sqlite3_value_text(value)), sqlite3_value_bytes(value));
 	}
 
-	inline void store_result_in_db(sqlite3_context* db, STR_REF val) {
+	inline void store_result_in_db(sqlite3_context* db, str_ref val) {
 		sqlite3_result_text(db, val.data(), val.length(), SQLITE_TRANSIENT);
 	}
-	// U16STR_REF
+	// u16str_ref
 	template<>
 	struct has_sqlite_type<std::u16string, SQLITE3_TEXT, void> : std::true_type {};
-	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, U16STR_REF val) {
+	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, u16str_ref val) {
 		return sqlite3_bind_text16(stmt, inx, val.data(), sizeof(char16_t) * val.length(), SQLITE_TRANSIENT);
 	}
 
-	// Convert char* to string_view to trigger op<<(..., const STR_REF )
+	// Convert char* to string_view to trigger op<<(..., const str_ref )
 	template<std::size_t N> inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const char16_t(&STR)[N]) { 
 		return sqlite3_bind_text16(stmt, inx, &STR[0], N-1, SQLITE_TRANSIENT);
 	}
@@ -206,7 +212,7 @@ namespace sqlite {
 			std::u16string(reinterpret_cast<char16_t const *>(sqlite3_value_text16(value)), sqlite3_value_bytes16(value));
 	}
 
-	inline void store_result_in_db(sqlite3_context* db, U16STR_REF val) {
+	inline void store_result_in_db(sqlite3_context* db, u16str_ref val) {
 		sqlite3_result_text16(db, val.data(), sizeof(char16_t) * val.length(), SQLITE_TRANSIENT);
 	}
 

--- a/hdr/sqlite_modern_cpp/type_wrapper.h
+++ b/hdr/sqlite_modern_cpp/type_wrapper.h
@@ -37,11 +37,11 @@
 #endif
 #ifdef MODERN_SQLITE_STRINGVIEW_SUPPORT
 #include <string_view>
-#define STR_REF std::string_view
-#define U16STR_REF std::u16string_view
+typedef std::string_view STR_REF;
+typedef std::u16string_view U16STR_REF;
 #else
-#define STR_REF std::string
-#define U16STR_REF std::u16string
+typedef std::string STR_REF;
+typedef std::u16string U16STR_REF;
 #endif
 #include <sqlite3.h>
 #include "errors.h"

--- a/hdr/sqlite_modern_cpp/type_wrapper.h
+++ b/hdr/sqlite_modern_cpp/type_wrapper.h
@@ -167,7 +167,7 @@ namespace sqlite {
 	template<>
 	struct has_sqlite_type<std::string, SQLITE3_TEXT, void> : std::true_type {};
 	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const STR_REF& val) {
-		return sqlite3_bind_text(stmt, inx, val.data(), -1, SQLITE_TRANSIENT);
+		return sqlite3_bind_text(stmt, inx, val.data(), val.length(), SQLITE_TRANSIENT);
 	}
 
 	// Convert char* to string_view to trigger op<<(..., const STR_REF )
@@ -183,13 +183,13 @@ namespace sqlite {
 	}
 
 	inline void store_result_in_db(sqlite3_context* db, const STR_REF& val) {
-		sqlite3_result_text(db, val.data(), -1, SQLITE_TRANSIENT);
+		sqlite3_result_text(db, val.data(), val.length(), SQLITE_TRANSIENT);
 	}
 	// U16STR_REF
 	template<>
 	struct has_sqlite_type<std::u16string, SQLITE3_TEXT, void> : std::true_type {};
 	inline int bind_col_in_db(sqlite3_stmt* stmt, int inx, const U16STR_REF& val) {
-		return sqlite3_bind_text16(stmt, inx, val.data(), -1, SQLITE_TRANSIENT);
+		return sqlite3_bind_text16(stmt, inx, val.data(), sizeof(char16_t) * val.length(), SQLITE_TRANSIENT);
 	}
 
 	// Convert char* to string_view to trigger op<<(..., const STR_REF )
@@ -205,7 +205,7 @@ namespace sqlite {
 	}
 
 	inline void store_result_in_db(sqlite3_context* db, const U16STR_REF& val) {
-		sqlite3_result_text16(db, val.data(), -1, SQLITE_TRANSIENT);
+		sqlite3_result_text16(db, val.data(), sizeof(char16_t) * val.length(), SQLITE_TRANSIENT);
 	}
 
 	// Other integer types

--- a/hdr/sqlite_modern_cpp/utility/utf16_utf8.h
+++ b/hdr/sqlite_modern_cpp/utility/utf16_utf8.h
@@ -8,7 +8,7 @@
 
 namespace sqlite {
 	namespace utility {
-		inline std::string utf16_to_utf8(const std::u16string &input) {
+		inline std::string utf16_to_utf8(const U16STR_REF &input) {
 			struct : std::codecvt<char16_t, char, std::mbstate_t> {
 			} codecvt;
 			std::mbstate_t state{};

--- a/hdr/sqlite_modern_cpp/utility/utf16_utf8.h
+++ b/hdr/sqlite_modern_cpp/utility/utf16_utf8.h
@@ -8,7 +8,7 @@
 
 namespace sqlite {
 	namespace utility {
-		inline std::string utf16_to_utf8(const U16STR_REF &input) {
+		inline std::string utf16_to_utf8(u16str_ref input) {
 			struct : std::codecvt<char16_t, char, std::mbstate_t> {
 			} codecvt;
 			std::mbstate_t state{};

--- a/tests/flags.cc
+++ b/tests/flags.cc
@@ -13,8 +13,9 @@ struct TmpFile {
 	TmpFile(): fname("./flags.db") { }
 	~TmpFile() { remove(fname.c_str()); }
 };
-
-#if BYTE_ORDER == BIG_ENDIAN
+#ifdef _WIN32
+#define OUR_UTF16 "UTF-16le"
+#elif BYTE_ORDER == BIG_ENDIAN
 #define OUR_UTF16 "UTF-16be"
 #else
 #define OUR_UTF16 "UTF-16le"

--- a/tests/string_view.cc
+++ b/tests/string_view.cc
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <cstdlib>
+#include <sqlite_modern_cpp.h>
+#include <catch.hpp>
+
+
+#ifdef MODERN_SQLITE_STRINGVIEW_SUPPORT
+#include <string_view>
+
+using namespace sqlite;
+using namespace std;
+TEST_CASE("std::string_view works", "[string_view]") {
+	database db(":memory:");;
+	db << "CREATE TABLE foo (a integer, b string);\n";
+	const std::string_view test1 = "null terminated string view";
+	db << "INSERT INTO foo VALUES (?, ?)" << 1 << test1;
+	std::string str;
+	db << "SELECT b from FOO where a=?;" << 1 >> str;
+	REQUIRE(test1 == str);
+	const char s[] = "hello world";
+	std::string_view test2(&s[0], 2);
+	db << "INSERT INTO foo VALUES (?,?)" << 2 << test2;
+	db << "SELECT b from FOO where a=?" << 2 >> str;
+	REQUIRE(str == "he");
+}
+#endif


### PR DESCRIPTION
The major benefit is if someone tries to bind a `char*` parameter, we can avoid an extra copy that would happen if a new `std::string` was created from it. This pull request also includes some improvements for building/running the tests on MSVC, mostly because I suck at git and didn't know how to separate them into a separate pull request. 