### PR TITLE
Support for named and indexed parameters

### DIFF
--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -36,17 +36,13 @@ namespace sqlite {
 		T value;
 	};
 
-	inline namespace literals {
-		inline auto operator ""_sqlparam(const char *name, std::size_t) {
-			return [name](auto &&arg) {
-				return index_binding_helper<decltype(arg), true>{name, std::forward<decltype(arg)>(arg)};
-			};
-		}
-		inline auto operator ""_sqlparam(unsigned long long index) {
-			return [index](auto &&arg) {
-				return index_binding_helper<decltype(arg)>{index, std::forward<decltype(arg)>(arg)};
-			};
-		}
+	template<class T>
+	auto named_parameter(const char *name, T &&arg) {
+		return index_binding_helper<decltype(arg), true>{name, std::forward<decltype(arg)>(arg)};
+	}
+	template<class T>
+	auto indexed_parameter(int index, T &&arg) {
+		return index_binding_helper<decltype(arg)>{index, std::forward<decltype(arg)>(arg)};
 	}
 
 	class row_iterator;

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -26,6 +26,29 @@ namespace sqlite {
 
 	typedef std::shared_ptr<sqlite3> connection_type;
 
+	template<class T, bool Name = false>
+	struct index_binding_helper {
+		index_binding_helper(const index_binding_helper &) = delete;
+#if __cplusplus < 201703
+		index_binding_helper(index_binding_helper &&) = default;
+#endif
+		typename std::conditional<Name, const char *, int>::type index;
+		T value;
+	};
+
+	inline namespace literals {
+		inline auto operator ""_sqlparam(const char *name, std::size_t) {
+			return [name](auto &&arg) {
+				return index_binding_helper<decltype(arg), true>{name, std::forward<decltype(arg)>(arg)};
+			};
+		}
+		inline auto operator ""_sqlparam(unsigned long long index) {
+			return [index](auto &&arg) {
+				return index_binding_helper<decltype(arg)>{index, std::forward<decltype(arg)>(arg)};
+			};
+		}
+	}
+
 	class row_iterator;
 	class database_binder {
 
@@ -101,6 +124,8 @@ namespace sqlite {
 		}
 
 		template<typename T> friend database_binder& operator<<(database_binder& db, T&&);
+		template<typename T> friend database_binder& operator<<(database_binder& db, index_binding_helper<T>);
+		template<typename T> friend database_binder& operator<<(database_binder& db, index_binding_helper<T, true>);
 		friend void operator++(database_binder& db, int);
 
 	public:
@@ -480,6 +505,25 @@ namespace sqlite {
 	// Some ppl are lazy so we have a operator for proper prep. statemant handling.
 	void inline operator++(database_binder& db, int) { db.execute(); }
 
+	template<typename T> database_binder &operator<<(database_binder& db, index_binding_helper<T> val) {
+		db._next_index(); --db._inx;
+		int result = bind_col_in_db(db._stmt.get(), val.index, std::forward<T>(val.value));
+		if(result != SQLITE_OK)
+			exceptions::throw_sqlite_error(result, db.sql());
+		return db;
+	}
+
+	template<typename T> database_binder &operator<<(database_binder& db, index_binding_helper<T, true> val) {
+		db._next_index(); --db._inx;
+		int index = sqlite3_bind_parameter_index(db._stmt.get(), val.index);
+		if(!index)
+			throw errors::unknown_binding("The given binding name is not valid for this statement", db.sql());
+		int result = bind_col_in_db(db._stmt.get(), index, std::forward<T>(val.value));
+		if(result != SQLITE_OK)
+			exceptions::throw_sqlite_error(result, db.sql());
+		return db;
+	}
+
 	template<typename T> database_binder &operator<<(database_binder& db, T&& val) {
 		int result = bind_col_in_db(db._stmt.get(), db._next_index(), std::forward<T>(val));
 		if(result != SQLITE_OK)
@@ -488,6 +532,7 @@ namespace sqlite {
 	}
 	// Convert the rValue binder to a reference and call first op<<, its needed for the call that creates the binder (be carefull of recursion here!)
 	template<typename T> database_binder operator << (database_binder&& db, const T& val) { db << val; return std::move(db); }
+	template<typename T, bool Name> database_binder operator << (database_binder&& db, index_binding_helper<T, Name> val) { db << index_binding_helper<T, Name>{val.index, std::forward<T>(val.value)}; return std::move(db); }
 
 	namespace sql_function_binder {
 		template<class T>

--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -39,6 +39,7 @@ namespace sqlite {
 		class no_rows: public sqlite_exception { using sqlite_exception::sqlite_exception; };
 		class more_statements: public sqlite_exception { using sqlite_exception::sqlite_exception; }; // Prepared statements can only contain one statement
 		class invalid_utf16: public sqlite_exception { using sqlite_exception::sqlite_exception; };
+		class unknown_binding: public sqlite_exception { using sqlite_exception::sqlite_exception; };
 
 		static void throw_sqlite_error(const int& error_code, str_ref sql = "") {
 			switch(error_code & 0xFF) {

--- a/tests/named.cc
+++ b/tests/named.cc
@@ -11,7 +11,7 @@ TEST_CASE("binding named parameters works", "[named]") {
     db << "CREATE TABLE foo (a,b);";
 
     int a = 1;
-    db << "INSERT INTO foo VALUES (:first,:second)" << ":second"_sqlparam(2) << ":first"_sqlparam(a);
+    db << "INSERT INTO foo VALUES (:first,:second)" << named_parameter(":second", 2) << named_parameter(":first", a);
 
     db << "SELECT b FROM foo WHERE a=?;" << 1 >> a;
 

--- a/tests/named.cc
+++ b/tests/named.cc
@@ -1,0 +1,19 @@
+#include <iostream>
+#include <cstdlib>
+#include <sqlite_modern_cpp.h>
+#include <catch.hpp>
+using namespace sqlite;
+using namespace std;
+
+TEST_CASE("binding named parameters works", "[named]") {
+    database db(":memory:");
+
+    db << "CREATE TABLE foo (a,b);";
+
+    int a = 1;
+    db << "INSERT INTO foo VALUES (:first,:second)" << ":second"_sqlparam(2) << ":first"_sqlparam(a);
+
+    db << "SELECT b FROM foo WHERE a=?;" << 1 >> a;
+
+    REQUIRE(a == 2);
+}


### PR DESCRIPTION
This is a UDL based attempt to support binding named parameters: For example

    db << "INSERT INTO t VALUES(:firstname, :lastname, :birthday);"
       << ":birthday"_sqlparam("2000-01-01")
       << ":firstname"_sqlparam("John")
       << ":lastname"_sqlparam("Doe");

I am not really happ with the name `_sqlparam`. Does somebody have a better idea?
Another question is how to handle mixed positional and named parameters: Currently `_sqlparam` paameters are ignored in the normal order, so for example

    db << "SELECT :abc, ?;" << ":abc"_sqlparam(1) << 2;

would bind both parameters, `1` and `2`, to `:abc` so the result would be `2, NULL`.
This is not perfect but I do not know about a better way and using both named and `?` parameters together is advised against in the SQLite manual anyway, so fixing this might not be the top priority.