### PR TITLE
Don't include experimental/optional if on Apple clang 11

### DIFF
--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -14,7 +14,7 @@
 #ifdef __has_include
 #if __cplusplus > 201402 && __has_include(<optional>)
 #define MODERN_SQLITE_STD_OPTIONAL_SUPPORT
-#elif __has_include(<experimental/optional>)
+#elif __has_include(<experimental/optional>) && __apple_build_version__ < 11000000
 #define MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
 #endif
 #endif


### PR DESCRIPTION
In Apple clang 11 (Xcode 11) experimental/optional emits a warning that it has been removed, i.e building with xcode 11 fails as it seems experimental::optional is available.
This PR  fixes that by not setting MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT if building with Apple clang 11 or above.