### PR TITLE
upgrade hunter to newest version (to support MSVC 2019); upgrade to Catch2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,13 @@ SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set (CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+set(HUNTER_TLS_VERIFY ON)
 include("cmake/HunterGate.cmake")
 include("cmake/Catch.cmake")
 
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.19.227.tar.gz"
-    SHA1 "808b778a443fcdf19c2d18fea8fa4bb59d16596a"
+    URL "https://github.com/ruslo/hunter/archive/v0.23.214.tar.gz"
+    SHA1 "e14bc153a7f16d6a5eeec845fb0283c8fad8c358"
 )
 
 project(SqliteModernCpp)
@@ -19,7 +20,7 @@ project(SqliteModernCpp)
 hunter_add_package(Catch)
 hunter_add_package(sqlite3)
 
-find_package(Catch CONFIG REQUIRED)
+find_package(Catch2 CONFIG REQUIRED)
 find_package(sqlite3 CONFIG REQUIRED)
 
 set(TEST_SOURCE_DIR             ${CMAKE_SOURCE_DIR}/tests)
@@ -37,9 +38,9 @@ target_include_directories(sqlite_modern_cpp INTERFACE hdr/)
 add_executable(tests ${TEST_SOURCES})
 target_include_directories(tests INTERFACE ${SQLITE3_INCLUDE_DIRS})
 if(ENABLE_SQLCIPHER_TESTS)
-    target_link_libraries(tests Catch::Catch sqlite_modern_cpp sqlite3::sqlite3 -lsqlcipher)
+    target_link_libraries(tests Catch2::Catch2 sqlite_modern_cpp sqlite3::sqlite3 -lsqlcipher)
 else()
-    target_link_libraries(tests Catch::Catch sqlite_modern_cpp sqlite3::sqlite3)
+    target_link_libraries(tests Catch2::Catch2 sqlite_modern_cpp sqlite3::sqlite3)
 endif()
 
 catch_discover_tests(tests)

--- a/tests/blob_example.cc
+++ b/tests/blob_example.cc
@@ -2,7 +2,7 @@
 #include <cstdlib>
 #include <vector>
 #include <string>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <sqlite_modern_cpp.h>
 using namespace  sqlite;
 using namespace std;

--- a/tests/error_log.cc
+++ b/tests/error_log.cc
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <sqlite_modern_cpp.h>
 #include <sqlite_modern_cpp/log.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace sqlite;
 using namespace std;
 

--- a/tests/exception_dont_execute.cc
+++ b/tests/exception_dont_execute.cc
@@ -3,7 +3,7 @@
 #include <memory>
 #include <stdexcept>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace sqlite;
 using namespace std;
 

--- a/tests/exception_dont_execute_nested.cc
+++ b/tests/exception_dont_execute_nested.cc
@@ -3,7 +3,7 @@
 #include <memory>
 #include <stdexcept>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace sqlite;
 using namespace std;
 

--- a/tests/exceptions.cc
+++ b/tests/exceptions.cc
@@ -4,7 +4,7 @@
 #include <memory>
 #include <stdexcept>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace sqlite;
 using namespace std;
 

--- a/tests/flags.cc
+++ b/tests/flags.cc
@@ -3,7 +3,7 @@
 #include <cstdlib>
 #include <sqlite_modern_cpp.h>
 #include <sys/types.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace sqlite;
 using namespace std;
 

--- a/tests/functions.cc
+++ b/tests/functions.cc
@@ -2,7 +2,7 @@
 #include <cstdlib>
 #include <cmath>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace  sqlite;
 using namespace std;
 

--- a/tests/functors.cc
+++ b/tests/functors.cc
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <string>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 using namespace sqlite;
 using namespace std;

--- a/tests/lvalue_functor.cc
+++ b/tests/lvalue_functor.cc
@@ -2,7 +2,7 @@
 #include<sqlite_modern_cpp.h>
 #include<string>
 #include<vector>
-#include<catch.hpp>
+#include<catch2/catch.hpp>
 using namespace  sqlite;
 using namespace std;
 

--- a/tests/mov_ctor.cc
+++ b/tests/mov_ctor.cc
@@ -3,7 +3,7 @@
 #include <cstdlib>
 #include <sqlite_modern_cpp.h>
 #include <memory>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace  sqlite;
 using namespace std;
 

--- a/tests/named.cc
+++ b/tests/named.cc
@@ -1,9 +1,10 @@
 #include <iostream>
 #include <cstdlib>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace sqlite;
 using namespace std;
+
 
 TEST_CASE("binding named parameters works", "[named]") {
     database db(":memory:");

--- a/tests/nullptr_uniqueptr.cc
+++ b/tests/nullptr_uniqueptr.cc
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace std;
 using namespace sqlite;
 

--- a/tests/prepared_statment.cc
+++ b/tests/prepared_statment.cc
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace  sqlite;
 using namespace std;
 

--- a/tests/readme_example.cc
+++ b/tests/readme_example.cc
@@ -1,6 +1,6 @@
 #define CATCH_CONFIG_MAIN
 #include<iostream>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <sqlite_modern_cpp.h>
 
 using namespace sqlite;

--- a/tests/shared_connection.cc
+++ b/tests/shared_connection.cc
@@ -2,7 +2,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 using namespace  sqlite;
 using namespace std;

--- a/tests/simple_examples.cc
+++ b/tests/simple_examples.cc
@@ -2,7 +2,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace sqlite;
 using namespace std;
 

--- a/tests/std_optional.cc
+++ b/tests/std_optional.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 using namespace sqlite;
 using namespace std;

--- a/tests/string_view.cc
+++ b/tests/string_view.cc
@@ -1,5 +1,5 @@
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 
 #ifdef MODERN_SQLITE_STRINGVIEW_SUPPORT

--- a/tests/trycatchblocks.cc
+++ b/tests/trycatchblocks.cc
@@ -3,7 +3,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 using namespace sqlite;
 using std::string;

--- a/tests/variant.cc
+++ b/tests/variant.cc
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <sqlite_modern_cpp.h>
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 using namespace sqlite;
 using namespace std;
 


### PR DESCRIPTION
New hunter make use of `HUNTER_TLS_VERIFY` variable in cmake -- I have switched in `ON`.

For some reason after upgrading the hunter, I couldn't build because `Catch` was not found (hunter would install it but it looks like now it uses `Catch2` package instead of `Catch`...)
I figured out that `CMakeLists.txt` needs updating: `s/Catch/Catch2/`. This works for me on Windows and Linux.