### PR TITLE
Revert "Document the difference between `execute` and `++`"

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,9 @@ ps >> [&](int a,int b){ ... };
 
 // after a successfull execution the statment can be executed again, but the bound values are resetted.
 // If you dont need the returned values you can execute it like this
-ps++; // Does reset the bound values
+ps.execute();
 // or like this
-ps.execute(); // Does NOT reset the bound values, but we can reset them manually:
-ps.reset();
+ps++;
 
 // To disable the execution of a statment when it goes out of scope and wasn't used
 ps.used(true); // or false if you want it to execute even if it was used
@@ -133,7 +132,7 @@ auto ps = db << "insert into complex_table_with_lots_of_indices values (?,?,?)";
 int i = 0;
 while( i < 100000 ){
    ps << long_list[i++] << long_list[i++] << long_list[i++];
-   ps++; // Equal to: ps.execute(); ps.reset();
+   ps++;
 }
 ```
 


### PR DESCRIPTION
Reverts SqliteModernCpp/sqlite_modern_cpp#178

#178 had not to be merged at least because `reset` method was removed from public access of `database_binder` in https://github.com/SqliteModernCpp/sqlite_modern_cpp/commit/05ea5a8ee9cc68b68d73533781f77fca033e9f7f