### PR TITLE
Improve CMake to add sqlite_modern_cpp to other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ hunter_add_package(sqlite3)
 find_package(Catch2 CONFIG REQUIRED)
 find_package(sqlite3 CONFIG REQUIRED)
 
-set(TEST_SOURCE_DIR             ${CMAKE_SOURCE_DIR}/tests)
+set(TEST_SOURCE_DIR             ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 file(GLOB TEST_SOURCES          ${TEST_SOURCE_DIR}/*.cc)
 
 IF(NOT ENABLE_SQLCIPHER_TESTS)


### PR DESCRIPTION
I had problems with the TEST SOURCE_DIR variable being incorrectly defined after adding this library to my project. It seems that using CMAKE_CURRENT_SOURCE_DIR is more correct in this case.