### PR TITLE
Store error message also for basic return codes.

### DIFF
--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -31,7 +31,7 @@ namespace sqlite {
 		using Index = std::conditional_t<Name, const char *, int>;
 
 		index_binding_helper(const index_binding_helper &) = delete;
-#if __cplusplus < 201703 || _MSVC_LANG && _MSVC_LANG <= 201703
+#if __cplusplus < 201703 || _MSVC_LANG // && _MSVC_LANG <= 201703
 		index_binding_helper(index_binding_helper &&) = default;
 #endif
 		index_binding_helper(Index index_, T value_) :

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -31,6 +31,9 @@ namespace sqlite {
 		index_binding_helper(const index_binding_helper &) = delete;
 #if __cplusplus < 201703 || _MSVC_LANG <= 201703
 		index_binding_helper(index_binding_helper &&) = default;
+#elif _MSVC_LANG > 201703
+		index_binding_helper(typename std::conditional<Name, const char*, int>::type index_, T value_) :
+			index(index_), value(value_) { }
 #endif
 		typename std::conditional<Name, const char *, int>::type index;
 		T value;

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -28,14 +28,16 @@ namespace sqlite {
 
 	template<class T, bool Name = false>
 	struct index_binding_helper {
+		using Index = std::conditional_t<Name, const char *, int>;
+
 		index_binding_helper(const index_binding_helper &) = delete;
-#if __cplusplus < 201703 || _MSVC_LANG <= 201703
+#if __cplusplus < 201703 || _MSVC_LANG && _MSVC_LANG <= 201703
 		index_binding_helper(index_binding_helper &&) = default;
-#elif _MSVC_LANG > 201703
-		index_binding_helper(typename std::conditional<Name, const char*, int>::type index_, T value_) :
-			index(index_), value(value_) { }
 #endif
-		typename std::conditional<Name, const char *, int>::type index;
+		index_binding_helper(Index index_, T value_) :
+			index(index_), value(value_) { }
+
+		Index index;
 		T value;
 	};
 

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -31,9 +31,9 @@ namespace sqlite {
 		using Index = std::conditional_t<Name, const char *, int>;
 
 		index_binding_helper(const index_binding_helper &) = delete;
-#if __cplusplus < 201703 || _MSVC_LANG // && _MSVC_LANG <= 201703
+//#if __cplusplus < 201703 || _MSVC_LANG // && _MSVC_LANG <= 201703
 		index_binding_helper(index_binding_helper &&) = default;
-#endif
+//#endif
 		index_binding_helper(Index index_, T value_) :
 			index(index_), value(value_) { }
 

--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -48,7 +48,7 @@ namespace sqlite {
 				case SQLITE_ ## NAME: switch(error_code) {          \
 					derived                                           \
 					case SQLITE_ ## NAME:                             \
-					default: throw name(error_code, sql);             \
+					default: throw name(error_code, sql, errmsg);     \
 				}
 
 #if SQLITE_VERSION_NUMBER < 3010000


### PR DESCRIPTION
While `throw_sqlite_error` is called with the return value of `sqlite3_errmsg` everywhere, `throw_sqlite_error` uses this argument only for extended result codes, and discards it for basic ones. ced361fec35623863b24775b715b474f0b6b9cae must have left that out by accident.